### PR TITLE
[FIX] query_history unpack ohlcv error 和 not use req.start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vim
+*.swp

--- a/vnpy_okx/okx_gateway.py
+++ b/vnpy_okx/okx_gateway.py
@@ -416,7 +416,7 @@ class OkxRestApi(RestClient):
                     break
 
                 for bar_list in data["data"]:
-                    ts, o, h, l, c, vol, _ = bar_list
+                    ts, o, h, l, c, vol, *_ = bar_list
                     dt = parse_timestamp(ts)
                     bar: BarData = BarData(
                         symbol=req.symbol,

--- a/vnpy_okx/okx_gateway.py
+++ b/vnpy_okx/okx_gateway.py
@@ -377,12 +377,14 @@ class OkxRestApi(RestClient):
 
     def query_history(self, req: HistoryRequest) -> List[BarData]:
         """
-        查询历史数据
+        查询历史数据, API Doc: https://www.okx.com/docs-v5/en/#rest-api-market-data-get-candlesticks
 
         K线数据每个粒度最多可获取最近1440条
         """
         buf: Dict[datetime, BarData] = {}
         end_time: str = ""
+        # Minus 1 (ms) is to get data from the bar at start_time, not start_time + interval.
+        start_time: str = str(int(req.start.timestamp() * 1e3 - 1))
         path: str = "/api/v5/market/candles"
 
         for i in range(15):
@@ -392,6 +394,7 @@ class OkxRestApi(RestClient):
                 "bar": INTERVAL_VT2OKX[req.interval]
             }
 
+            params["before"] = start_time
             if end_time:
                 params["after"] = end_time
 


### PR DESCRIPTION
- 修复 query_history 接口 ohlcv 解析失败，返回数据超过  7 个；
- 修复 start 未使用，查询结果包含有 start 前的数据；